### PR TITLE
Enable optional speech output

### DIFF
--- a/OK workspaces/cli.py
+++ b/OK workspaces/cli.py
@@ -1,13 +1,10 @@
 from hecate import Hecate
 import argparse
 import speech_recognition as sr
-import subprocess
+from speech import speak
+import os
 
-def speak(text):
-    try:
-        subprocess.run(["espeak", text], check=True)
-    except Exception:
-        pass
+ENV_SPEAK = os.getenv("SPEAK_RESPONSES", "false").lower() in ("1", "true", "yes")
 
 
 def voice_chat(bot, speak_output=False):
@@ -58,13 +55,15 @@ if __name__ == '__main__':
     parser.add_argument("--speak", action="store_true", help="Speak responses aloud")
     args = parser.parse_args()
 
+    speak_flag = args.speak or ENV_SPEAK
+
     bot = Hecate()
     intro = bot.startup_message()
     if intro:
         print(intro)
-        if args.speak:
+        if speak_flag:
             speak(intro)
     if args.voice:
-        voice_chat(bot, speak_output=args.speak)
+        voice_chat(bot, speak_output=speak_flag)
     else:
-        text_chat(bot, speak_output=args.speak)
+        text_chat(bot, speak_output=speak_flag)

--- a/OK workspaces/main.py
+++ b/OK workspaces/main.py
@@ -6,6 +6,9 @@ import subprocess
 import sys
 import os
 import speech_recognition as sr
+from speech import speak
+
+SPEAK_RESPONSES = os.getenv("SPEAK_RESPONSES", "false").lower() in ("1", "true", "yes")
 
 app = Flask(__name__)
 CORS(app)
@@ -28,6 +31,8 @@ def talk():
     data = request.json
     user_input = data.get("message", "")
     response = hecate.respond(user_input)
+    if SPEAK_RESPONSES:
+        speak(response)
     try:
         with open("conversation.log", "a") as log:
             log.write(f"User: {user_input}\n")
@@ -51,6 +56,8 @@ def talk_audio():
     except Exception as e:
         return jsonify({"error": f"Speech recognition failed: {e}"}), 400
     response = hecate.respond(text)
+    if SPEAK_RESPONSES:
+        speak(response)
     return jsonify({"transcript": text, "reply": response})
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -122,10 +122,17 @@ You can also enable speech-to-text input with the `--voice` flag (requires a mic
 python "OK workspaces/cli.py" --voice
 ```
 
-To hear the responses spoken aloud, add the `--speak` flag (requires pyttsx3):
+To hear the responses spoken aloud, add the `--speak` flag (requires `espeak`):
 
 ```bash
 python "OK workspaces/cli.py" --speak
+```
+
+You can also enable speech output for the API server or any clone by setting the
+`SPEAK_RESPONSES` environment variable:
+
+```bash
+export SPEAK_RESPONSES=true
 ```
 
 ### Gmail Integration

--- a/speech.py
+++ b/speech.py
@@ -1,0 +1,10 @@
+import subprocess
+
+def speak(text: str):
+    """Speak the given text using espeak if available."""
+    if not text:
+        return
+    try:
+        subprocess.run(["espeak", text], check=True)
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- add a simple `speech.py` helper
- allow the API server to speak responses when `SPEAK_RESPONSES` is set
- let the CLI honour `SPEAK_RESPONSES`
- document the new environment variable

## Testing
- `python -m py_compile "OK workspaces/cli.py" "OK workspaces/main.py" "speech.py"`

------
https://chatgpt.com/codex/tasks/task_e_6887dcd60b8c832faf96186e180ed72a